### PR TITLE
Release 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@
 - Add support to test current model output against previously known good model output to guard against regressions when the model is changed.
 - Add support for command line options to control validation, input folder and output folder so that environment variables are not needed.
 - Added documentation about command line operation with flowcharts about how LandBOSSE processes data according to the command line.
+
+## 2.1.3 (October 29, 2019)
+
+- Removed an empty and unimplemented function from `DefaultMasterInputDict.py`.

--- a/landbosse/model/DefaultMasterInputDict.py
+++ b/landbosse/model/DefaultMasterInputDict.py
@@ -1,17 +1,3 @@
-def default_master_input_dict():
-    """
-    Returns a master input dictionary populated with entirely defualt values
-
-    Currently it does not return any of the keys that require dataframes.
-    It only returns the keys that have simple values.
-
-    Returns
-    -------
-    dict
-        Default values for the master input dict
-    """
-
-
 class DefaultMasterInputDict:
     """
     DefaultMasterInput is a class that handles all the default values


### PR DESCRIPTION
This cleans an unused function out of the source file `DefaultMasterInputDict.py`. This function had no implementation and was formerly called `default_master_input_dict()`. The function's functionality is handled entirely by the `DefaultMasterInputDict` class. This release does not implement that class' functionality; rather, it just clean up the old code that existed before the class was created.

The `DefaultMasterInputDict` class has been operational since the 2.0.0 release.