### PR TITLE
Issue #45 Speed up XlsxReader file parsing.

### DIFF
--- a/landbosse/excelio/XlsxReader.py
+++ b/landbosse/excelio/XlsxReader.py
@@ -99,27 +99,28 @@ class XlsxReader:
             'components'
         ]
 
+        project_data = pd.ExcelFile(input_xlsx)
+
         erection_project_data_dict = dict()
         for worksheet in erection_input_worksheets:
-            erection_project_data_dict[worksheet] = pd.read_excel(input_xlsx, worksheet)
+            erection_project_data_dict[worksheet] = project_data.parse(worksheet)
 
         # Add the erection project data to the incomplete_input_dict
         incomplete_input_dict['project_data'] = erection_project_data_dict
 
         # Get the first set of data
-        incomplete_input_dict['rsmeans'] = pd.read_excel(input_xlsx, 'rsmeans')
-        incomplete_input_dict['site_facility_building_area_df'] = pd.read_excel(input_xlsx,
-                                                                                'site_facility_building_area')
-        incomplete_input_dict['material_price'] = pd.read_excel(input_xlsx, 'material_price')
+        incomplete_input_dict['rsmeans'] = project_data.parse('rsmeans')
+        incomplete_input_dict['site_facility_building_area_df'] = project_data.parse('site_facility_building_area')
+        incomplete_input_dict['material_price'] = project_data.parse('material_price')
 
         # The weather window is stored on a sheet of the project_data, but
         # needs preprocessing after it is read. The preprocessing changes it
         # from wind toolkit format to a dataframe.
-        weather_window_input_df = pd.read_excel(input_xlsx, 'weather_window')
+        weather_window_input_df = project_data.parse('weather_window')
         incomplete_input_dict['weather_window'] = read_weather_window(weather_window_input_df)
 
         # Read development tab:
-        incomplete_input_dict['development_df'] = pd.read_excel(input_xlsx, 'development')
+        incomplete_input_dict['development_df'] = project_data.parse('development')
 
         # FoundationCost needs to have all the component data split into separate
         # NumPy arrays.

--- a/landbosse/excelio/XlsxReader.py
+++ b/landbosse/excelio/XlsxReader.py
@@ -10,7 +10,7 @@ class XlsxReader:
     This class is for reading input data from .xlsx files.
 
     There are two sets of data to be read from .xlsx files. The first set
-    of data is read from the following tabs:
+    of data is read from the following sheets:
 
     - components
 
@@ -36,7 +36,7 @@ class XlsxReader:
 
     - weather_window
 
-    And the second set is read from a
+    The second set of data are read from a single sheet as described below.
 
     The first set of data represent a database used by the various modules. Queries
     on these data allow calculation based on labor, material, crane capacity

--- a/landbosse/model/DefaultMasterInputDict.py
+++ b/landbosse/model/DefaultMasterInputDict.py
@@ -21,7 +21,7 @@ class DefaultMasterInputDict:
     def populate_input_dict(self, incomplete_input_dict):
         """
         Completely fills the input_dict. If there are any keys in the
-        default input dictionary that are not on input_dict, those
+        default input dictionary that are not on incomplete_input_dict, those
         missing key/value pairs are placed on a fully populated input
         dictionary.
 


### PR DESCRIPTION
This PR speeds up the `.xlsx` file parsing in `XlsxReader.py`. Here are my measurements of the speedup, using the release 2.1.3 dataset. 

Speed of the original implementation using the validation dataset (which is a four project list)

Original implementation, serial execution: **27 seconds**
New implementation, serial execution: **13 seconds**
Original implementation, parallel execution: **9 seconds**
New implementation, parallel execution: **5 seconds**

Test it using the command appropriate for your environment. With something like

```
python main.py -I /Users/akey/ProprietaryData/inputs -o /Users/akey/ProprietaryData/outputs --validate
```


Or, use the following procedure to duplicate the timing results.

The times were measured running a validation operation with the following command (adjust it to whatever file paths work on your system)

```
date && python main.py -i /Users/akey/ProprietaryData/inputs -o /Users/akey/ProprietaryData/outputs --validate && date
```

The `date &&` and `&& date` at the beginning and end display the start and end timestamps of the run.

Making a standard log of start and end times could be added with another commit.