### PR TITLE
Issue 26 crew prices and weather delays in output sheet

### DIFF
--- a/landbosse/excelio/XlsxGenerator.py
+++ b/landbosse/excelio/XlsxGenerator.py
@@ -179,8 +179,7 @@ class XlsxGenerator:
             value = row['value']
             value_is_number = self._is_numeric(value)
             if value_is_number:
-                # worksheet.write(row_idx + 1, 5, value, self.scientific_format)
-                worksheet.write(row_idx + 1, 5, value)
+                worksheet.write(row_idx + 1, 5, value, self.scientific_format)
             else:
                 worksheet.write(row_idx + 1, 6, value)
 

--- a/landbosse/excelio/XlsxGenerator.py
+++ b/landbosse/excelio/XlsxGenerator.py
@@ -179,15 +179,25 @@ class XlsxGenerator:
             value = row['value']
             value_is_number = self._is_numeric(value)
             if value_is_number:
-                worksheet.write(row_idx + 1, 5, value, self.scientific_format)
+                # worksheet.write(row_idx + 1, 5, value, self.scientific_format)
+                worksheet.write(row_idx + 1, 5, value)
             else:
                 worksheet.write(row_idx + 1, 6, value)
 
             # If there is a last_number, which means this is a dataframe row that has a number
-            # at the end, write this into the numeric value column.
+            # at the end, write this into the numeric value column. This overrides automatic
+            # type detection.
 
             if 'last_number' in row:
-                worksheet.write(row_idx + 1, 5, row['last_number'], self.scientific_format)
+                # worksheet.write(row_idx + 1, 5, row['last_number'], self.scientific_format)
+                worksheet.write(row_idx + 1, 5, row['last_number'])
+
+            # Certain data are pairs of numeric and non-numeric values. If a key of
+            # "non_numeric_value" exists, put that in column 6.
+            # An example is mobilization of an LB75-SL3F-Offload at some numeric cost
+
+            if 'non_numeric_value' in row:
+                worksheet.write(row_idx + 1, 6, row['non_numeric_value'])
 
         worksheet.freeze_panes(1, 0)  # Freeze the first row.
 

--- a/landbosse/model/ErectionCost.py
+++ b/landbosse/model/ErectionCost.py
@@ -249,6 +249,17 @@ class ErectionCost(CostModule):
                 'non_numeric_value': crane_boom_operation_concat
             })
 
+        for _, row in self.output_dict['erection_selected_detailed_data'].iterrows():
+            value = row['Wind multiplier']
+            operation = row['Operation']
+            result.append({
+                'unit': '',
+                'type': 'dataframe',
+                'variable_df_key_col_name': f'erection_selected_detailed_data: wind multiplier',
+                'value': value,
+                'non_numeric_value': operation
+            })
+
         result.append({
             'unit': 'usd',
             'type': 'variable',

--- a/landbosse/model/ErectionCost.py
+++ b/landbosse/model/ErectionCost.py
@@ -227,6 +227,16 @@ class ErectionCost(CostModule):
                 'last_number': row[2]
             })
 
+        for _, row in self.output_dict['erection_selected_detailed_data'].iterrows():
+            value = row[5]
+            crew_operation = row[2]
+            result.append({
+                'unit': '',
+                'type': 'dataframe',
+                'variable_df_key_col_name': f'erection_selected_detailed_data: {crew_operation} crew cost',
+                'value': value
+            })
+
         result.append({
             'unit': 'usd',
             'type': 'variable',
@@ -1062,3 +1072,4 @@ class ErectionCost(CostModule):
         # Management crews data
         self.output_dict['management_crews_cost'] = management_crews_cost
         self.output_dict['management_crews_cost_grouped'] = management_crews_cost_grouped
+        self.output_dict['erection_selected_detailed_data'] = selected_detailed_data

--- a/landbosse/model/ErectionCost.py
+++ b/landbosse/model/ErectionCost.py
@@ -228,13 +228,25 @@ class ErectionCost(CostModule):
             })
 
         for _, row in self.output_dict['erection_selected_detailed_data'].iterrows():
-            value = row[5]
-            crew_operation = row[2]
+            value = row['Labor cost USD']
+            operation = row['Operation']
             result.append({
-                'unit': '',
+                'unit': 'usd',
                 'type': 'dataframe',
-                'variable_df_key_col_name': f'erection_selected_detailed_data: {crew_operation} crew cost',
-                'value': value
+                'variable_df_key_col_name': f'erection_selected_detailed_data: crew cost',
+                'value': value,
+                'non_numeric_value': operation
+            })
+
+        for _, row in self.output_dict['erection_selected_detailed_data'].iterrows():
+            value = row['Mobilization cost USD']
+            crane_boom_operation_concat = row['crane_boom_operation_concat']
+            result.append({
+                'unit': 'usd',
+                'type': 'dataframe',
+                'variable_df_key_col_name': 'erection_selected_detailed_data: mobilization',
+                'value': value,
+                'non_numeric_value': crane_boom_operation_concat
             })
 
         result.append({


### PR DESCRIPTION
This PR adds support for placing:

1. weather multiplier for each operation
1. Mobilization cost for each operation
1. Crew cost for each operation

Each set of data is under a different name in the sheet so that it is easy to filter and display in Tableau.

The images show the relevant parts of the details sheet

![Screen Shot 2019-11-07 at 07 40 23](https://user-images.githubusercontent.com/2609896/68398570-35279300-0132-11ea-9288-804580cfbe13.png)

![Screen Shot 2019-11-07 at 07 41 32](https://user-images.githubusercontent.com/2609896/68398584-38bb1a00-0132-11ea-8456-49a8518c60a5.png)

![Screen Shot 2019-11-07 at 07 41 59](https://user-images.githubusercontent.com/2609896/68398591-3bb60a80-0132-11ea-99f9-5159dab9fd03.png)
