### PR TITLE
removing Pandas deprecation warnings 

### DIFF
--- a/landbosse/model/ErectionCost.py
+++ b/landbosse/model/ErectionCost.py
@@ -916,11 +916,11 @@ class ErectionCost(CostModule):
         same_topbase_crane_list = possible_crane_topbase[['Crane name', 'Boom system']]
         possible_crane_topbase  = same_topbase_crane_list.merge(possible_crane_cost, on=['Crane name', 'Boom system'])
         possible_crane_topbase_sum = possible_crane_topbase.groupby(['Crane name',
-                                                                     'Boom system'])['Labor cost USD without management',
+                                                                     'Boom system'])[['Labor cost USD without management',
                                                                                      'Subtotal for hourly labor (non-management) USD',
                                                                                      'Subtotal for per diem labor (non-management) USD',
                                                                                      'Equipment rental cost USD',
-                                                                                     'Fuel cost USD'
+                                                                                     'Fuel cost USD']
         ].sum().reset_index()
 
         # Store the possible cranes for the top and base for future diagnostics.
@@ -948,11 +948,11 @@ class ErectionCost(CostModule):
 
         # calculate costs if top and base use separate cranes
         separate_topbase = \
-            possible_crane_cost.groupby(['Operation', 'Crane name', 'Boom system'])['Labor cost USD without management',
+            possible_crane_cost.groupby(['Operation', 'Crane name', 'Boom system'])[['Labor cost USD without management',
                                                                                                    'Subtotal for hourly labor (non-management) USD',
                                                                                                    'Subtotal for per diem labor (non-management) USD',
                                                                                                    'Equipment rental cost USD',
-                                                                                                   'Fuel cost USD'
+                                                                                                   'Fuel cost USD']
         ].sum().reset_index()
 
         # join mobilization data to separate top base crane costs


### PR DESCRIPTION
This simple change seems to fix:

FutureWarning: Indexing with multiple keys (implicitly converted to a tuple of keys) will be deprecated, use a list instead.

Reference:
https://stackoverflow.com/questions/60999753/pandas-future-warning-indexing-with-multiple-keys