### PR TITLE
Remove shapely from LandBOSSE - Issue #151

### DIFF
--- a/landbosse/model/ErectionCost.py
+++ b/landbosse/model/ErectionCost.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
-from shapely.geometry import Point
-from shapely.geometry.polygon import Polygon
+from sympy import Point
+from sympy import Polygon
 from math import ceil
 
 from .CostModule import CostModule
@@ -643,7 +643,8 @@ class ErectionCost(CostModule):
             setup_time = max(crane['Setup time hr'])
             breakdown_time = max(crane['Breakdown time hr'])
             crew_type = crane.loc[0, 'Crew type ID'] # For every crane/boom combo the crew is the same, so we can just take first crew.
-            polygon = Polygon([(0, 0), (0, max(y)), (min(x), max(y)), (max(x), min(y)), (max(x), 0)])
+            p1, p2, p3, p4, p5 = map(Point, [(0, 0), (0, max(y)), (min(x), max(y)), (max(x), min(y)), (max(x), 0)])
+            polygon = Polygon(p1, p2, p3, p4, p5)
             df = pd.DataFrame([[equipment_name,
                                 equipment_id,
                                 crane_name,
@@ -726,7 +727,7 @@ class ErectionCost(CostModule):
                     point = Point(component_only['Mass tonne'] / 2, (component_only['Section height m'] + component_only['Offload hook height m']))
                 else:
                     point = Point(component_only['Mass tonne'], (component_only['Lift height m'] + component_only['Offload hook height m']))
-                crane['Lift boolean {component}'.format(component=component)] = polygon.contains(point)
+                crane['Lift boolean {component}'.format(component=component)] = polygon.encloses_point(point)
 
             # Transform the "Lift boolean" indexes in the series to a list of booleans
             # that signify if the crane can lift a component.

--- a/landbosse/model/ErectionCost.py
+++ b/landbosse/model/ErectionCost.py
@@ -644,7 +644,9 @@ class ErectionCost(CostModule):
             breakdown_time = max(crane['Breakdown time hr'])
             crew_type = crane.loc[0, 'Crew type ID'] # For every crane/boom combo the crew is the same, so we can just take first crew.
             p1, p2, p3, p4, p5 = map(Point, [(0, 0), (0, max(y)), (min(x), max(y)), (max(x), min(y)), (max(x), 0)])
+            # print(f"Erection points {p1} {p2} {p3} {p4} {p5}")
             polygon = Polygon(p1, p2, p3, p4, p5)
+            # print(f"Erection Polygon points {p1} {p2} {p3} {p4} {p5}")
             df = pd.DataFrame([[equipment_name,
                                 equipment_id,
                                 crane_name,


### PR DESCRIPTION
Replaced shapely with sympy. 

Please note, shapely was phased out and replaced with sympy back in February '20 (refer to issue #103 and PR #104). However, due to the timing of that change coinciding with the then ongoing cost and scaling work, PR #104 was merged into pip_installable branch only (not develop) to (1) prevent any possible disruption of the cost & scaling work (as in, introduction of bugs for instance), and (2) it was only needed at that point in time for the LandBOSSE / SAM integration project. 

This PR has made the exact same changes to the ErectionCost.py file (compared to PR #104); this PR is focusing now on phasing out shapely (and replacing with sympy) for the develop branch. 