### PR TITLE
Syncing with new orbit approach to commissioning and decommissioning

### DIFF
--- a/landbosse/landbosse_omdao/OpenMDAODataframeCache.py
+++ b/landbosse/landbosse_omdao/OpenMDAODataframeCache.py
@@ -87,6 +87,7 @@ class OpenMDAODataframeCache:
         for sheet_name in xlsx.sheet_names:
             sheets_dict[sheet_name].dropna(inplace=True, how='all')
         cls._cache[xlsx_basename] = sheets_dict
+        xlsx.close()
         return cls.copy_dataframes(sheets_dict)
 
     @classmethod

--- a/landbosse/landbosse_omdao/landbosse.py
+++ b/landbosse/landbosse_omdao/landbosse.py
@@ -31,8 +31,8 @@ class LandBOSSE(om.Group):
 
         self.set_input_defaults("turbine_spacing_rotor_diameters", 4)
         self.set_input_defaults("row_spacing_rotor_diameters", 10)
-        self.set_input_defaults("commissioning_pct", 0.01)
-        self.set_input_defaults("decommissioning_pct", 0.15)
+        self.set_input_defaults("commissioning_cost_kW", 44.0, units="USD/kW")
+        self.set_input_defaults("decommissioning_cost_kW", 58.0, units="USD/kW")
         self.set_input_defaults("trench_len_to_substation_km", 50.0, units="km")
         self.set_input_defaults("interconnect_voltage_kV", 130.0, units="kV")
 
@@ -42,7 +42,7 @@ class LandBOSSE(om.Group):
         self.set_input_defaults("nacelle_mass", 50e3, units="kg")
         self.set_input_defaults("tower_mass", 240e3, units="kg")
         self.set_input_defaults("turbine_rating_MW", 1500.0, units="kW")
-        self.set_input_defaults("turbine_capex", 0.0, units="USD/kW")
+        self.set_input_defaults("turbine_capex_kW", 0.0, units="USD/kW")
 
         self.add_subsystem("landbosse", LandBOSSE_API(), promotes=["*"])
 
@@ -102,6 +102,7 @@ class LandBOSSE_API(om.ExplicitComponent):
         self.add_input("hub_height_meters", val=80, units="m", desc="Hub height m")
         self.add_input("rotor_diameter_m", val=77, units="m", desc="Rotor diameter m")
         self.add_input("wind_shear_exponent", val=0.2, desc="Wind shear exponent")
+        self.add_input("turbine_capex_kW", val=0.0, units="USD/kW", desc="Turbine capital cost")
         self.add_input("turbine_rating_MW", val=1.5, units="MW", desc="Turbine rating MW")
         self.add_input("fuel_cost_usd_per_gal", val=1.5, desc="Fuel cost USD/gal")
 
@@ -164,9 +165,8 @@ class LandBOSSE_API(om.ExplicitComponent):
         # Disabled due to Pandas conflict right now.
         self.add_input("labor_cost_multiplier", val=1.0, desc="Labor cost multiplier")
 
-        self.add_input("commissioning_pct", 0.01)
-        self.add_input("decommissioning_pct", 0.15)
-        self.add_input("turbine_capex", 0.0, units="USD/kW")
+        self.add_input("commissioning_cost_kW", 44.0, units="USD/kW", desc="Commissioning cost.")
+        self.add_input("decommissioning_cost_kW", 58.0, units="USD/kW", desc="Decommissioning cost.")
 
     def setup_discrete_inputs_that_are_not_dataframes(self):
         """
@@ -450,6 +450,9 @@ class LandBOSSE_API(om.ExplicitComponent):
             discrete_inputs["num_turbines"] * inputs["turbine_rating_MW"][0]
         )
 
+        # Turbine Capex
+        incomplete_input_dict["turbine_capex"] = float(inputs["turbine_capex_kW"][0])
+        
         # Needed to avoid distributed wind keys
         incomplete_input_dict["road_distributed_wind"] = False
 
@@ -586,24 +589,23 @@ class LandBOSSE_API(om.ExplicitComponent):
         installation_per_kW = 0.0
 
         for row in costs_by_module_type_operation:
+            if row["Module"] in ["TurbineCost"]:
+                continue
             bos_per_kw += row["Cost / kW"]
             bos_per_project += row["Cost / project"]
             if row["Module"] in ["ErectionCost", "FoundationCost"]:
                 installation_per_project += row["Cost / project"]
                 installation_per_kW += row["Cost / kW"]
 
-        commissioning_pct = inputs["commissioning_pct"]
-        decommissioning_pct = inputs["decommissioning_pct"]
+        commissioning_kW = inputs["commissioning_cost_kW"]
+        decommissioning_kW = inputs["decommissioning_cost_kW"]
 
-        commissioning_per_project = bos_per_project * commissioning_pct
-        decomissioning_per_project = bos_per_project * decommissioning_pct
-        commissioning_per_kW = bos_per_kw * commissioning_pct
-        decomissioning_per_kW = bos_per_kw * decommissioning_pct
+        capacity = bos_per_project / bos_per_kw
 
-        outputs["total_capex_kW"] = bos_per_kw + commissioning_per_kW + decomissioning_per_kW
-        outputs["total_capex"] = bos_per_project + commissioning_per_project + decomissioning_per_project
         outputs["bos_capex"] = bos_per_project
         outputs["bos_capex_kW"] = bos_per_kw
+        outputs["total_capex_kW"] = bos_per_kw + commissioning_kW + decommissioning_kW
+        outputs["total_capex"] = bos_per_project + capacity*(commissioning_kW + decommissioning_kW)
         outputs["installation_capex"] = installation_per_project
         outputs["installation_capex_kW"] = installation_per_kW
 


### PR DESCRIPTION
## Purpose
This PR has:
- Sync with latest `turbine_capex` input in LandBOSSE, but ensure it is not included in tally of BOS costs
- Change the calculation of commissioning and decommissioning to be consistent with ORBIT.  The new approach is also likely a more sustainable.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation